### PR TITLE
DL-2054-fix Amended ACM-FE connector URI

### DIFF
--- a/app/connectors/AgentClientMandateFrontendConnector.scala
+++ b/app/connectors/AgentClientMandateFrontendConnector.scala
@@ -29,7 +29,7 @@ class AgentClientMandateFrontendConnector @Inject()(appConfig: ApplicationConfig
                                                     http: DefaultHttpClient
                                                    ) extends RawResponseReads {
 
-  val serviceUrl: String = appConfig.serviceUrlACM
+  val serviceUrl: String = appConfig.serviceUrlACMFrontend
   val emailUri = "mandate/agent/email-session"
   val displayNameUri = "mandate/agent/client-display-name-session"
   val mandateDetails = "mandate/agent/old-nonuk-mandate-from-session"


### PR DESCRIPTION
# DL-2054-fix Amended ACM-FE connector URI

**Bug fix**

* **Do not merge until ACM-FE auth fix has been deployed**
* This commit amends `ated-subscription-frontend`'s connector for `agent-client-mandate-frontend` to point to ACM-FE instead of ACM.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date