### PR TITLE
DL-2760 Added pages for overseas companies registering

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -68,6 +68,8 @@ class ApplicationConfig @Inject()(val servicesConfig: ServicesConfig,
 
   lazy val reviewDetailsPath: String = servicesConfig.getConfString(
     "business-customer.reviewDetailsUrl","/business-customer/review-details/ATED")
+  lazy val nrlPath: String = servicesConfig.getConfString(
+    "business-customer.nrlUrl","/business-customer/nrl/ATED")
   lazy val agentAtedSummaryPath: String = servicesConfig.getConfString(
     "agent-client-mandate-frontend.agentAtedSummaryUrl", "/mandate/agent/summary")
   lazy val clientDisplayNameEditPath: String = servicesConfig.getConfString(

--- a/app/connectors/AtedSubscriptionDataCacheConnector.scala
+++ b/app/connectors/AtedSubscriptionDataCacheConnector.scala
@@ -29,6 +29,7 @@ class AtedSubscriptionDataCacheConnector @Inject()(sessionCache: AtedSessionCach
   val bcRegDetailseId: String = "BC_BusinessReg_Details"
   val addressFormId: String = "Correspondence_Address"
   val contactFormId: String = "Contact_Details"
+  val previousSubmittedFormId: String = "Previously_Submitted"
   val mandateAgentEmailFormId: String = "agent-email"
   val clientDisplayNameFormId = "client-display-name-form-id"
   val contactEmailFormId: String = "Contact_Email_Details"
@@ -85,6 +86,17 @@ class AtedSubscriptionDataCacheConnector @Inject()(sessionCache: AtedSessionCach
     sessionCache.cache[ContactDetailsEmail](contactEmailFormId, contactDetailsEmail) map { cachedData =>
       cachedData.getEntry[ContactDetailsEmail](contactEmailFormId)
     }
+  }
+
+  def savePreviouslySubmitted(previousSubmittedForm: PreviousSubmittedForm)
+                             (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PreviousSubmittedForm]] = {
+    sessionCache.cache[PreviousSubmittedForm](previousSubmittedFormId, previousSubmittedForm) map { cachedData =>
+      cachedData.getEntry[PreviousSubmittedForm](previousSubmittedFormId)
+    }
+  }
+
+  def fetchPreviouslySubmittedForSession(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PreviousSubmittedForm]] = {
+    sessionCache.fetchAndGetEntry[PreviousSubmittedForm](previousSubmittedFormId)
   }
 
 }

--- a/app/controllers/PreviousSubmittedController.scala
+++ b/app/controllers/PreviousSubmittedController.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.ApplicationConfig
+import connectors.BusinessCustomerFrontendConnector
+import controllers.auth.AuthFunctionality
+import forms.AtedForms
+import javax.inject.Inject
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.OverseasCompanyService
+import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PreviousSubmittedController @Inject()(mcc: MessagesControllerComponents,
+                                            businessCustomerFEConnector: BusinessCustomerFrontendConnector,
+                                            overseasCompanyService: OverseasCompanyService,
+                                            val authConnector: DefaultAuthConnector,
+                                            implicit val appConfig: ApplicationConfig
+                                           ) extends FrontendController(mcc) with AuthFunctionality {
+
+  implicit val ec: ExecutionContext = mcc.executionContext
+
+  def view: Action[AnyContent] = Action.async {
+    implicit request =>
+      authoriseFor { implicit data =>
+        overseasCompanyService.fetchPreviouslySubmitted.map { optPreviouslySubmitted =>
+          val form = optPreviouslySubmitted match {
+            case Some(answer) => AtedForms.previousSubmittedForm.fill(answer)
+            case _ => AtedForms.previousSubmittedForm
+          }
+
+          Ok(views.html.previous_submitted(form, Some(appConfig.backToBusinessCustomerUrl)))
+        }
+      }
+  }
+
+  def continue: Action[AnyContent] = Action.async {
+    implicit request =>
+      authoriseFor { implicit data =>
+        AtedForms.previousSubmittedForm.bindFromRequest().fold(
+          hasErrors =>
+            Future.successful(BadRequest(views.html.previous_submitted(hasErrors, Some(appConfig.backToBusinessCustomerUrl)))),
+          success => {
+            val answer = success.isPreviousSubmitted
+            answer match {
+              case Some(prevSubmitted) =>
+                overseasCompanyService.savePreviouslySubmitted(success) map { _ =>
+                  if (prevSubmitted) {
+                    Redirect(routes.SameAccountController.viewSameAccount())
+                  } else {
+                    Redirect(appConfig.nrlPath)
+                  }
+                }
+              case _ => Future.successful(Redirect(routes.PreviousSubmittedController.view()))
+            }
+          }
+        )
+      }
+  }
+}

--- a/app/controllers/SameAccountController.scala
+++ b/app/controllers/SameAccountController.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.ApplicationConfig
+import connectors.BusinessCustomerFrontendConnector
+import controllers.auth.AuthFunctionality
+import javax.inject.Inject
+import models.BusinessCustomerDetails
+import org.joda.time.LocalDate
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import uk.gov.hmrc.play.views.formatting.Dates
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SameAccountController @Inject()(mcc: MessagesControllerComponents,
+                                      businessCustomerFEConnector: BusinessCustomerFrontendConnector,
+                                      val authConnector: DefaultAuthConnector,
+                                      implicit val appConfig: ApplicationConfig
+                                     ) extends FrontendController(mcc) with AuthFunctionality {
+
+  implicit val ec: ExecutionContext = mcc.executionContext
+
+  def viewSameAccount: Action[AnyContent] = Action.async {
+    implicit request =>
+      authoriseFor { implicit data =>
+        Future.successful(Ok(views.html.sameAccount(Some(controllers.routes.PreviousSubmittedController.view().url))))
+      }
+  }
+
+  def viewInform: Action[AnyContent] = Action.async {
+    implicit request =>
+      authoriseFor { implicit data =>
+        Future.successful(Ok(views.html.inform(Some(controllers.routes.SameAccountController.viewSameAccount().url))))
+      }
+  }
+
+  def toNRLQuestionPage: Action[AnyContent] = Action.async {
+    implicit request =>
+      authoriseFor { implicit data =>
+        Future.successful(Redirect(appConfig.nrlPath))
+      }
+  }
+}

--- a/app/forms/AtedForms.scala
+++ b/app/forms/AtedForms.scala
@@ -62,6 +62,11 @@ object AtedForms {
       .verifying("ated.claim-relief.error.agent-appoint", result => result.isDefined)
   )(AppointAgentForm.apply)(AppointAgentForm.unapply))
 
+  val previousSubmittedForm = Form(mapping(
+    "previousSubmitted" -> optional(boolean)
+      .verifying("ated.claim-relief.error.previous-submitted", result => result.isDefined)
+  )(PreviousSubmittedForm.apply)(PreviousSubmittedForm.unapply))
+
 
   val businessAddressForm = Form(mapping(
     "isCorrespondenceAddress" -> optional(boolean)

--- a/app/models/ated.scala
+++ b/app/models/ated.scala
@@ -30,6 +30,12 @@ object AppointAgentForm {
   implicit val formats: OFormat[AppointAgentForm] = Json.format[AppointAgentForm]
 }
 
+case class PreviousSubmittedForm(isPreviousSubmitted: Option[Boolean] = None)
+
+object PreviousSubmittedForm {
+  implicit val formats: OFormat[PreviousSubmittedForm] = Json.format[PreviousSubmittedForm]
+}
+
 case class Address(
                     line_1: String,
                     line_2: String,

--- a/app/services/OverseasCompanyService.scala
+++ b/app/services/OverseasCompanyService.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.AtedSubscriptionDataCacheConnector
+import javax.inject.Inject
+import models.PreviousSubmittedForm
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class OverseasCompanyService @Inject()(dataCacheConnector: AtedSubscriptionDataCacheConnector) {
+
+  def savePreviouslySubmitted(previousSubmittedForm: PreviousSubmittedForm)
+                        (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PreviousSubmittedForm]] = {
+    dataCacheConnector.savePreviouslySubmitted(previousSubmittedForm)
+  }
+
+  def fetchPreviouslySubmitted(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[PreviousSubmittedForm]] = {
+    dataCacheConnector.fetchPreviouslySubmittedForSession
+  }
+
+}

--- a/app/views/helpers/pageHeadersAndError.scala.html
+++ b/app/views/helpers/pageHeadersAndError.scala.html
@@ -19,14 +19,14 @@
 @if(backLink.isDefined){
   <a id="backLinkHref" class="link-back" href='@backLink'>@Messages("ated.back")</a>
   @errorDisplay
-<header class="page-header">
-  <h1 id="@headerId" class="heading-xlarge">@headerValue</h1>
-  <p id="@subHeaderId" class="heading-secondary"><span class="visuallyhidden">@Messages("ated.screen-reader.section") </span>@subHeaderValue</p>
+<header class="page-header page-header-margin">
+    <p id="@subHeaderId" class="heading-secondary"><span class="visuallyhidden">@Messages("ated.screen-reader.section") </span>@subHeaderValue</p>
+    <h1 id="@headerId" class="heading-xlarge">@headerValue</h1>
 </header>
 } else {
   @errorDisplay
 <header class="page-header page-header-margin">
-  <h1 id="@headerId" class="heading-xlarge">@headerValue</h1>
-  <p id="@subHeaderId" class="heading-secondary page-header-no-margin"><span class="visuallyhidden">@Messages("ated.screen-reader.section") </span>@subHeaderValue</p>
+    <p id="@subHeaderId" class="heading-secondary page-header-no-margin"><span class="visuallyhidden">@Messages("ated.screen-reader.section") </span>@subHeaderValue</p>
+    <h1 id="@headerId" class="heading-xlarge">@headerValue</h1>
 </header>
 }

--- a/app/views/inform.scala.html
+++ b/app/views/inform.scala.html
@@ -1,0 +1,43 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.ApplicationConfig
+@(backLink: Option[String])(implicit request: Request[_], authContext: AtedSubscriptionAuthData, messages: Messages, appConfig: ApplicationConfig)
+@import uk.gov.hmrc.play.views.html._
+@import uk.gov.hmrc.play.views.html.helpers._
+@import views.html.helpers._
+
+
+@atedMain(title = messages("ated.inform.title")) {
+
+    <a id="backLinkHref" class="link-back" href='@backLink'>@Messages("ated.back")</a>
+    <div class="page-header page-header-margin">
+         <h1 class="heading-xlarge">@messages("ated.inform.title")</h1>
+        <p class="heading-secondary page-header-no-margin"><span class="visuallyhidden">@Messages("ated.screen-reader.section") </span>@messages("ated.registration-subheader")</p>
+    </div>
+
+    <p>@messages("ated.inform.p1")</p>
+
+    <p class="margin-bottom-default">@messages("ated.inform.p2")</p>
+
+    <p class="margin-bottom-default">@messages("ated.inform.use-the-email")</p>
+
+    <p class="margin-bottom-default">@messages("ated.inform.p3")</p>
+
+    @form(action = controllers.routes.SameAccountController.toNRLQuestionPage) {
+    <button class="button" id="submit" type="submit">@messages("ated.inform.continue-to-create")</button>
+    }
+}

--- a/app/views/previous_submitted.scala.html
+++ b/app/views/previous_submitted.scala.html
@@ -1,0 +1,67 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.ApplicationConfig
+@(previousSubmittedForm: Form[models.PreviousSubmittedForm], backLink: Option[String] = None)(implicit request: Request[_], authContext: AtedSubscriptionAuthData, messages: Messages, appConfig: ApplicationConfig)
+@import uk.gov.hmrc.play.views.html._
+@import uk.gov.hmrc.play.views.html.helpers._
+@import views.html.helpers._
+@import utils._
+
+@implicitFormInstance = @{ Some(previousSubmittedForm) }
+
+@pageScripts = {
+  <script src='@routes.Assets.at("javascript/show-hide-content.js")'></script>
+  <script>
+    $(document).ready(function() {
+      // Where .multiple-choice uses the data-target attribute
+      // to toggle hidden content
+      var showHideContent = new GOVUK.ShowHideContent()
+      showHideContent.init()
+    });
+  </script>
+}
+
+@atedNoAuthMain(title = messages("ated.prev-submitted.title"),
+                userLoggedIn = true,
+                pageScripts = Some(pageScripts)) {
+
+@pageHeadersAndError(backLink, "client-appoint-subheader", messages("ated.registration-subheader"), "client-startpage-header", messages("ated.prev-submitted.title"),
+    Some(atedErrorSummary(previousSubmittedForm, "ated.previous-submitted.general")))
+
+  <p>@messages("ated.prev-submitted.p1")</p>
+
+  @form(action = controllers.routes.PreviousSubmittedController.continue()) {
+
+    <div class="form-group" id="previousSubmitted">
+      @atedInputRadioGroupReveal(previousSubmittedForm("previousSubmitted"),
+        Seq("true" -> (messages("ated.radio.yes.label"), None),
+            "false" -> (messages("ated.radio.no.label"), None)),
+      '_legend -> messages("ated.prev-submitted.title"),
+      '_legendClass -> "visuallyhidden",
+      '_groupClass -> "inline",
+      '_labelClass -> "block-label",
+      '_labelAfter -> true,
+      '_trackGA -> true)
+
+
+    </div>
+
+    <button class="button" id="submit" type="submit" onclick="ga('send', 'event', 'Client - Previously Submitted', 'button clicked')">@messages("ated.continue")</button>
+
+  }
+
+}

--- a/app/views/sameAccount.scala.html
+++ b/app/views/sameAccount.scala.html
@@ -1,0 +1,43 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.ApplicationConfig
+@(backLink: Option[String])(implicit request: Request[_], authContext: AtedSubscriptionAuthData, messages: Messages, appConfig: ApplicationConfig)
+@import uk.gov.hmrc.play.views.html._
+@import uk.gov.hmrc.play.views.html.helpers._
+@import views.html.helpers._
+
+
+@atedMain(title = messages("ated.same-account.title")) {
+
+    <a id="backLinkHref" class="link-back" href='@backLink'>@Messages("ated.back")</a>
+    <div class="page-header page-header-margin">
+        <h1 class="heading-xlarge">@messages("ated.same-account.title")</h1>
+        <p class="heading-secondary page-header-no-margin"><span class="visuallyhidden">@Messages("ated.screen-reader.section") </span>@messages("ated.registration-subheader")</p>
+    </div>
+
+    <div>
+        <p>@messages("ated.same-account.p1")</p>
+
+        <p class="margin-bottom-default">@messages("ated.same-account.p2")</p>
+
+        @form(action = controllers.routes.ApplicationController.logout()) {
+        <button class="button margin-bottom-default" id="submit" type="submit">@messages("ated.same-account.sign-out")</button>
+        }
+
+        <p><a id="old-details" href="@controllers.routes.SameAccountController.viewInform()">@messages("ated.same-account.old-details")</a></p>
+    </div>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -48,4 +48,11 @@ POST                /agent/confirmation                         controllers.nonU
 GET                 /agent-confirmation                         controllers.AgentConfirmationController.view
 GET                 /agent-confirmation/continue/summary        controllers.AgentConfirmationController.continue
 
+GET                 /previous                                   controllers.PreviousSubmittedController.view
+POST                /previous                                   controllers.PreviousSubmittedController.continue
+
+GET                 /existing                                   controllers.SameAccountController.viewSameAccount
+GET                 /inform                                     controllers.SameAccountController.viewInform
+POST                /to-nrl                                     controllers.SameAccountController.toNRLQuestionPage
+
 GET                 /clear-cache                                controllers.ApplicationController.clearCache

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -110,6 +110,7 @@ microservice {
     business-customer {
       serviceRedirectUrl: "http://localhost:9923/business-customer/ATED?backLinkUrl=http://localhost:9933/ated-subscription/appoint-agent"
       reviewDetailsUrl: "http://localhost:9923/business-customer/review-details/ATED"
+      nrlUrl: "http://localhost:9923/business-customer/nrl/ATED"
       agentServiceRedirectUrl: "http://localhost:9923/business-customer/agent/ATED?backLinkUrl=http://localhost:9933/ated-subscription/start-agent-subscription"
       businessNameAndAddressEditUrl: "http://localhost:9923/business-customer/register/non-uk-client/ATED/edit?redirectUrl=http://localhost:9933/ated-subscription/review-business-details"
       overseasTaxReferenceEditUrl: "http://localhost:9923/business-customer/register/non-uk-client/edit-overseas-company/ATED/true?redirectUrl=http://localhost:9933/ated-subscription/review-business-details"

--- a/conf/messages
+++ b/conf/messages
@@ -305,6 +305,30 @@ ated.nonUKReg.confirmation.what-next = What happens next
 ated.nonUKReg.confirmation.what-next.text = You can create returns for your new client or add another client.
 ated.nonUKReg.confirmation.view-client.button = View all my clients
 
+#### PREVIOUS SUBMITTED PAGE
+
+ated.prev-submitted.title = Has this company submitted ATED returns before?
+ated.prev-submitted.p1 = This means returns submitted online by you or by an agent on your behalf (it does not include paper returns).
+ated.claim-relief.error.previous-submitted = Select yes if this company has submitted ATED returns before
+ated.previous-submitted.general.previousSubmitted = Select yes if this company has submitted ATED returns before
+
+#### SAME ACCOUNT PAGE
+
+ated.same-account.title = You need to use the same account as before
+ated.same-account.p1 = You need to find the Government Gateway details you used before to sign back into your existing account at https://www.tax.service.gov.uk/ated/home.
+ated.same-account.p2 = These details may be held by a colleague or by an agent who helped you register for ATED.
+ated.same-account.sign-out = Sign out
+ated.same-account.old-details = The old sign in details are not available
+
+#### INFORM PAGE
+
+ated.inform.title = Inform HMRC as soon as you create a new ATED account
+ated.inform.p1 = This is so we do not have to contact you about failure to submit returns from your old account.
+ated.inform.p2 = Contact HMRC using the subject line ‘Online Contact - Duplicate ATED Record Overseas Customer’.
+ated.inform.use-the-email = Use the email address: atedadditionalinfo.ctiaa@hmrc.gov.uk
+ated.inform.p3 = When emailing please include your ATED reference number or if you do not have the number please give your company name. Do not include any further personal or financial details. Sending information over the internet is generally not completely secure, and we cannot guarantee the security of your data while it’s in transit. Any data you send is at your own risk.
+ated.inform.continue-to-create = Continue to create new account
+
 ##### ERROR MESSAGES
 
 ated.business-registration-error.duplicate.identifier.header = Somebody has already registered from your organisation

--- a/test/connectors/DataCacheConnectorSpec.scala
+++ b/test/connectors/DataCacheConnectorSpec.scala
@@ -42,6 +42,7 @@ class DataCacheConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with M
   val testAgentEmail = AgentEmail("aa@aa.com")
   val clientDisplayName = ClientDisplayName("client display name")
   val testAddressForm = BusinessAddress(Some(true))
+  val previouslySubmitted = PreviousSubmittedForm(Some(true))
 
   val testAtedSubscriptionDataCacheConnector = new AtedSubscriptionDataCacheConnector(mockAtedSessionCache)
 
@@ -152,6 +153,25 @@ class DataCacheConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with M
         when(mockAtedSessionCache.fetchAndGetEntry[ContactDetailsEmail](ArgumentMatchers.any())(ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(testContactEmail)))
         val result = testAtedSubscriptionDataCacheConnector.fetchContactDetailsEmailForSession
         await(result).get must be (testContactEmail)
+      }
+    }
+
+    "savePreviouslySubmitted" must {
+      "save the previously submitted ATED returns question in keystore" in {
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+        val returnedCacheMap: CacheMap = CacheMap("data", Map("Previously_Submitted" -> Json.toJson(previouslySubmitted)))
+        when(mockAtedSessionCache.cache[PreviousSubmittedForm](ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(returnedCacheMap))
+        val result = testAtedSubscriptionDataCacheConnector.savePreviouslySubmitted(previouslySubmitted)
+        await(result).get must be (previouslySubmitted)
+      }
+    }
+
+    "fetchPreviouslySubmitted" must {
+      "fetch the previously submitted ATED returns question in keystore" in {
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+        when(mockAtedSessionCache.fetchAndGetEntry[PreviousSubmittedForm](ArgumentMatchers.any())(ArgumentMatchers.any(),ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(previouslySubmitted)))
+        val result = testAtedSubscriptionDataCacheConnector.fetchPreviouslySubmittedForSession
+        await(result).get must be (previouslySubmitted)
       }
     }
 

--- a/test/controllers/PreviousSubmittedControllerSpec.scala
+++ b/test/controllers/PreviousSubmittedControllerSpec.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import java.util.UUID
+
+import builders.{AuthBuilder, SessionBuilder}
+import connectors.BusinessCustomerFrontendConnector
+import models.PreviousSubmittedForm
+import org.jsoup.Jsoup
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.mvc.Result
+import play.api.test.Helpers._
+import services.OverseasCompanyService
+import testHelpers.AtedTestHelper
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class PreviousSubmittedControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with AtedTestHelper {
+
+  val mockBCConnector: BusinessCustomerFrontendConnector = mock[BusinessCustomerFrontendConnector]
+  val mockOverseasService: OverseasCompanyService = mock[OverseasCompanyService]
+  val testPreviousSubmittedController: PreviousSubmittedController = new PreviousSubmittedController(mockMCC, mockBCConnector, mockOverseasService, mockAuthConnector, mockAppConfig)
+
+  override def beforeEach(): Unit = {
+    reset(mockAuthConnector)
+    reset(mockRegisterUserService)
+    reset(mockBCConnector)
+    reset(mockOverseasService)
+  }
+
+  "PreviousSubmittedController" must {
+
+    "view" must {
+
+      "unauthorised users" must {
+        "respond with a redirect" in {
+          getWithUnAuthorisedUser { result =>
+            status(result) must be(SEE_OTHER)
+          }
+        }
+
+        "be redirected to the login page" in {
+          getWithUnAuthorisedUser { result =>
+            redirectLocation(result).get must include("/ated-subscription/unauthorised")
+          }
+        }
+      }
+
+      "Authorised users" must {
+
+        "respond with OK" in {
+          getWithAuthorisedUser("ACME LTD") { result =>
+            status(result) must be(OK)
+
+            val document = Jsoup.parse(contentAsString(result))
+            document.title() must be("Has this company submitted ATED returns before? - GOV.UK")
+          }
+        }
+
+        "respond with OK with prepopped data" in {
+          getWithAuthorisedUser("ACME LTD", Some(PreviousSubmittedForm(Some(true)))) { result =>
+            status(result) must be(OK)
+
+            val document = Jsoup.parse(contentAsString(result))
+            document.title() must be("Has this company submitted ATED returns before? - GOV.UK")
+          }
+        }
+      }
+    }
+
+    "continue" must {
+      "unauthorised users" must {
+        "respond with a redirect" in {
+          continueWithUnAuthorisedUser { result =>
+            status(result) must be(SEE_OTHER)
+            redirectLocation(result).get must include("/ated-subscription/unauthorised")
+          }
+        }
+      }
+
+      "Authorised users" must {
+
+        "go to the existing user page if they have previously submitted ated" in {
+          val inputForm = Seq(("previousSubmitted", "true"))
+
+          continueWithAuthorisedUser(inputForm) { result =>
+            status(result) must be(SEE_OTHER)
+            redirectLocation(result) must be(Some("/ated-subscription/existing"))
+          }
+        }
+
+        "go to the non-resident landlord page if they have not previously submitted" in {
+          val inputForm = Seq(("previousSubmitted", "false"))
+
+          when(mockAppConfig.nrlPath).thenReturn("test")
+
+          continueWithAuthorisedUser(inputForm) { result =>
+            status(result) must be(SEE_OTHER)
+            redirectLocation(result) must be(Some("test"))
+          }
+        }
+
+        "bad request if the form data is invalid" in {
+          val inputForm = Seq(("previousSubmitted", "invalid_data"))
+
+          continueWithAuthorisedUser(inputForm) { result =>
+            status(result) must be(BAD_REQUEST)
+          }
+        }
+      }
+    }
+  }
+
+  def getWithUnAuthorisedUser(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockUnAuthorisedUser(userId, mockAuthConnector)
+    val result = testPreviousSubmittedController.view().apply(SessionBuilder.buildRequestWithSession(userId))
+    test(result)
+  }
+
+  def getWithUnAuthenticated(test: Future[Result] => Any) {
+    val result = testPreviousSubmittedController.view().apply(SessionBuilder.buildRequestWithSessionNoUser())
+    test(result)
+  }
+
+
+  def getWithAuthorisedUser(businessName: String, data: Option[PreviousSubmittedForm] = None)(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockAuthorisedUser(userId, mockAuthConnector)
+
+    when(mockOverseasService.fetchPreviouslySubmitted(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(Future.successful(data))
+
+    val result = testPreviousSubmittedController.view().apply(SessionBuilder.buildRequestWithSession(userId))
+
+    test(result)
+  }
+
+  def continueWithUnAuthorisedUser(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockUnAuthorisedUser(userId, mockAuthConnector)
+    val result = testPreviousSubmittedController.continue.apply(SessionBuilder.buildRequestWithSession(userId))
+    test(result)
+  }
+
+  def continueWithUnAuthenticated(test: Future[Result] => Any) {
+    val result = testPreviousSubmittedController.continue.apply(SessionBuilder.buildRequestWithSessionNoUser())
+    test(result)
+  }
+
+
+  def continueWithAuthorisedUser(inputForm: Seq[(String, String)])(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockAuthorisedUser(userId, mockAuthConnector)
+
+    when(mockOverseasService.savePreviouslySubmitted(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(Future.successful(None))
+
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val result = testPreviousSubmittedController.continue.apply(SessionBuilder.buildRequestWithSession(userId).withFormUrlEncodedBody(inputForm: _*))
+
+    test(result)
+  }
+}

--- a/test/controllers/SameAccountControllerSpec.scala
+++ b/test/controllers/SameAccountControllerSpec.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import java.util.UUID
+
+import builders.{AuthBuilder, SessionBuilder}
+import connectors.BusinessCustomerFrontendConnector
+import models.{Address, BusinessCustomerDetails}
+import org.joda.time.LocalDate
+import org.jsoup.Jsoup
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import play.api.test.Helpers._
+import testHelpers.AtedTestHelper
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.views.formatting.Dates
+
+import scala.concurrent.Future
+
+class SameAccountControllerSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach with AtedTestHelper {
+
+  val mockBCConnector: BusinessCustomerFrontendConnector = mock[BusinessCustomerFrontendConnector]
+  val testSameAccountController: SameAccountController = new SameAccountController(mockMCC, mockBCConnector, mockAuthConnector, mockAppConfig)
+
+  override def beforeEach(): Unit = {
+    reset(mockAuthConnector)
+    reset(mockRegisterUserService)
+    reset(mockBCConnector)
+  }
+
+  "SameAccountController" must {
+
+    "viewSameAccount" must {
+
+      "unauthorised users" must {
+        "respond with a redirect" in {
+          getWithUnAuthorisedUser { result =>
+            status(result) must be(SEE_OTHER)
+          }
+        }
+
+        "be redirected to the login page" in {
+          getWithUnAuthorisedUser { result =>
+            redirectLocation(result).get must include("/ated-subscription/unauthorised")
+          }
+        }
+      }
+
+      "Authorised users" must {
+
+        "respond with OK" in {
+          getWithAuthorisedUser() { result =>
+            status(result) must be(OK)
+
+            val document = Jsoup.parse(contentAsString(result))
+            document.title() must be("You need to use the same account as before - GOV.UK")
+
+            document.getElementById("backLinkHref").attr("href") must include("previous")
+          }
+        }
+      }
+    }
+
+    "viewInform" must {
+
+      "unauthorised users" must {
+        "respond with a redirect" in {
+          getWithUnAuthorisedUserInform { result =>
+            status(result) must be(SEE_OTHER)
+          }
+        }
+
+        "be redirected to the login page" in {
+          getWithUnAuthorisedUserInform { result =>
+            redirectLocation(result).get must include("/ated-subscription/unauthorised")
+          }
+        }
+      }
+
+      "Authorised users" must {
+
+        "respond with OK" in {
+          getWithAuthorisedUserInform() { result =>
+            status(result) must be(OK)
+
+            val document = Jsoup.parse(contentAsString(result))
+            document.title() must be("Inform HMRC as soon as you create a new ATED account - GOV.UK")
+
+            document.getElementById("backLinkHref").attr("href") must include("existing")
+          }
+        }
+      }
+    }
+
+    "toNRLQuestionPage" must {
+
+      "unauthorised users" must {
+        "respond with a redirect" in {
+          getWithUnAuthorisedUserNRL { result =>
+            status(result) must be(SEE_OTHER)
+          }
+        }
+
+        "be redirected to the login page" in {
+          getWithUnAuthorisedUserNRL { result =>
+            redirectLocation(result).get must include("/ated-subscription/unauthorised")
+          }
+        }
+      }
+
+      "Authorised users" must {
+
+        "respond with OK" in {
+          getWithAuthorisedUserNRL() { result =>
+            status(result) must be(SEE_OTHER)
+          }
+        }
+      }
+    }
+  }
+
+  def getWithUnAuthorisedUser(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockUnAuthorisedUser(userId, mockAuthConnector)
+    val result = testSameAccountController.viewSameAccount().apply(SessionBuilder.buildRequestWithSession(userId))
+    test(result)
+  }
+
+  def getWithUnAuthenticated(test: Future[Result] => Any) {
+    val result = testSameAccountController.viewSameAccount().apply(SessionBuilder.buildRequestWithSessionNoUser())
+    test(result)
+  }
+
+
+  def getWithAuthorisedUser()(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockAuthorisedUser(userId, mockAuthConnector)
+
+    val result = testSameAccountController.viewSameAccount().apply(SessionBuilder.buildRequestWithSession(userId))
+
+    test(result)
+  }
+
+  def getWithUnAuthorisedUserInform(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockUnAuthorisedUser(userId, mockAuthConnector)
+    val result = testSameAccountController.viewInform().apply(SessionBuilder.buildRequestWithSession(userId))
+    test(result)
+  }
+
+  def getWithUnAuthenticatedInform(test: Future[Result] => Any) {
+    val result = testSameAccountController.viewInform().apply(SessionBuilder.buildRequestWithSessionNoUser())
+    test(result)
+  }
+
+
+  def getWithAuthorisedUserInform()(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockAuthorisedUser(userId, mockAuthConnector)
+
+    val result = testSameAccountController.viewInform().apply(SessionBuilder.buildRequestWithSession(userId))
+
+    test(result)
+  }
+
+  def getWithUnAuthorisedUserNRL(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockUnAuthorisedUser(userId, mockAuthConnector)
+    val result = testSameAccountController.toNRLQuestionPage().apply(SessionBuilder.buildRequestWithSession(userId))
+    test(result)
+  }
+
+  def getWithUnAuthenticatedNRL(test: Future[Result] => Any) {
+    val result = testSameAccountController.toNRLQuestionPage().apply(SessionBuilder.buildRequestWithSessionNoUser())
+    test(result)
+  }
+
+
+  def getWithAuthorisedUserNRL()(test: Future[Result] => Any) {
+    val userId = s"user-${UUID.randomUUID}"
+    AuthBuilder.mockAuthorisedUser(userId, mockAuthConnector)
+
+    val result = testSameAccountController.toNRLQuestionPage().apply(SessionBuilder.buildRequestWithSession(userId))
+
+    test(result)
+  }
+}

--- a/test/services/OverseasServiceSpec.scala
+++ b/test/services/OverseasServiceSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.AtedSubscriptionDataCacheConnector
+import models.{ContactDetails, ContactDetailsEmail, PreviousSubmittedForm}
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class OverseasServiceSpec extends PlaySpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterEach {
+
+  val mockDataCacheConnector: AtedSubscriptionDataCacheConnector = mock[AtedSubscriptionDataCacheConnector]
+  val testOverseasCompanyService: OverseasCompanyService = new OverseasCompanyService(mockDataCacheConnector)
+
+  val testPreviouslySubmitted = PreviousSubmittedForm(Some(true))
+
+  override def beforeEach: Unit = {
+    reset(mockDataCacheConnector)
+  }
+
+  "OverseasService" must {
+    "savePreviouslySubmitted" must {
+      "save previously submitted into keystore" in {
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+        when(mockDataCacheConnector.savePreviouslySubmitted(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(testPreviouslySubmitted)))
+        val result = testOverseasCompanyService.savePreviouslySubmitted(testPreviouslySubmitted)
+        await(result).get.toString must be(testPreviouslySubmitted.toString)
+        verify(mockDataCacheConnector, times(1)).savePreviouslySubmitted(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())
+      }
+    }
+    "fetchPreviouslySubmitted" must {
+      "return previously submitted, if found in keystore" in {
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+        when(mockDataCacheConnector.fetchPreviouslySubmittedForSession).thenReturn(Future.successful(Some(testPreviouslySubmitted)))
+        val result = testOverseasCompanyService.fetchPreviouslySubmitted
+        await(result) must be(Some(testPreviouslySubmitted))
+        verify(mockDataCacheConnector, times(1)).fetchPreviouslySubmittedForSession(ArgumentMatchers.any(), ArgumentMatchers.any())
+      }
+      "return None, if not found in keystore" in {
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+        when(mockDataCacheConnector.fetchPreviouslySubmittedForSession).thenReturn(Future.successful(None))
+        val result = testOverseasCompanyService.fetchPreviouslySubmitted
+        await(result) must be(None)
+        verify(mockDataCacheConnector, times(1)).fetchPreviouslySubmittedForSession(ArgumentMatchers.any(), ArgumentMatchers.any())
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
# DL-2760 Added pages for overseas companies registering

**New feature**

* Added pages for overseas ATED companies in the cases that they would create duplicate registrations.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date