### PR TITLE
Fixed bug where UTR was being set incorrectly to a blank string

### DIFF
--- a/app/models/EtmpModels.scala
+++ b/app/models/EtmpModels.scala
@@ -80,7 +80,7 @@ case class AtedSubscriptionRequest(acknowledgementReference: String,
                                    emailConsent: Boolean,
                                    address: List[EtmpCorrespondence],
                                    businessType: String,
-                                   utr: String,
+                                   utr: Option[String],
                                    isNonUKClientRegisteredByAgent : Boolean,
                                    knownFactPostcode: Option[String])
 

--- a/app/services/RegisterUserService.scala
+++ b/app/services/RegisterUserService.scala
@@ -156,7 +156,7 @@ class RegisterUserService @Inject()(appConfig: ApplicationConfig,
       emailConsent = contactEmail.emailConsent.getOrElse(false),
       address = List(correspondence),
       businessType = bcd.businessType,
-      utr = bcd.utr.getOrElse(""),
+      utr = bcd.utr,
       isNonUKClientRegisteredByAgent = nonUKAgent,
       knownFactPostcode = bcd.businessAddress.postcode)
     )

--- a/test/connectors/AtedSubscriptionConnectorSpec.scala
+++ b/test/connectors/AtedSubscriptionConnectorSpec.scala
@@ -56,7 +56,7 @@ class AtedSubscriptionConnectorSpec extends PlaySpec with GuiceOneServerPerSuite
     address = List(EtmpCorrespondence(name1 = "Joe", name2 = "Bloggs",
       addressDetails = EtmpAddressDetails("Correspondence", "line1", "line2", None, None, None, "GB"),
       contactDetails = EtmpContactDetails(Some("01234567890"), None, None, Some("a@b.c")))), emailConsent = true,
-    businessType = "Corporate Body", utr = "1234567890", isNonUKClientRegisteredByAgent = false, knownFactPostcode = Some("AA1 1AA"))
+    businessType = "Corporate Body", utr = Some("1234567890"), isNonUKClientRegisteredByAgent = false, knownFactPostcode = Some("AA1 1AA"))
   val subscribeDataJson: JsValue = Json.toJson(subscribeData)
 
   "AtedSubscriptionConnector" must {

--- a/test/models/AtedModelsSpec.scala
+++ b/test/models/AtedModelsSpec.scala
@@ -59,9 +59,37 @@ class AtedModelsSpec extends PlaySpec {
       | "isBusinessDetailsEditable":true
       |}""".stripMargin)
 
+  def businessCustomerDetailsJsonNoUtr(businessType: String): JsValue = Json.parse(
+    s"""{
+       | "businessName":"Logical Logistics",
+       | "businessType":"$businessType",
+       | "businessAddress": {
+       |   "line_1":"22 Gordon Road",
+       |   "line_2":"Riverside",
+       |   "line_3":"Town",
+       |   "line_4":"Shropshire",
+       |   "postcode":"TF2 8JP",
+       |   "country":"United Kingdom"
+       | },
+       | "sapNumber":"325435235235",
+       | "safeId":"2343534523",
+       | "agentReferenceNumber":"LARN123456",
+       | "directMatch":true,
+       | "identification": {
+       |   "idNumber":"123123",
+       |   "issuingInstitution":"Companies House",
+       |   "issuingCountryCode":"UK"
+       | },
+       | "isBusinessDetailsEditable":true
+       |}""".stripMargin)
+
   "BusinessCustomerDetails" should {
     "read correctly into a model" in {
       businessCustomerDetailsJson("Corporate Body").as[BusinessCustomerDetails] mustBe businessCustomerDetailsModel
+    }
+
+    "read correctly into a model when there is no utr" in {
+      businessCustomerDetailsJsonNoUtr("Corporate Body").as[BusinessCustomerDetails] mustBe businessCustomerDetailsModel.copy(utr = None)
     }
 
     "fail to read to a model if an invalid businessType has been provided" in {
@@ -70,6 +98,10 @@ class AtedModelsSpec extends PlaySpec {
 
     "write correctly to json all fields have been provided" in {
       Json.toJson(businessCustomerDetailsModel) mustBe businessCustomerDetailsJson("Corporate Body")
+    }
+
+    "write correctly to json when there is no utr" in {
+      Json.toJson(businessCustomerDetailsModel.copy(utr = None)) mustBe businessCustomerDetailsJsonNoUtr("Corporate Body")
     }
   }
 }

--- a/test/utils/TestJson.scala
+++ b/test/utils/TestJson.scala
@@ -45,7 +45,7 @@ trait TestJson {
       )
     )),
     businessType = "Corporate Body",
-    utr = "123456789",
+    utr = Some("123456789"),
     isNonUKClientRegisteredByAgent = true,
     knownFactPostcode = None
   )


### PR DESCRIPTION
Fixed bug where UTR was being set incorrectly to a blank string

Bug fix
In a non-agent, non-resident landlord journey were an SA utr is not provided, the utr was incorrectly being set to an empty string which caused a 400 response when setting up the known facts. The utr will now be set to None where it is not present and backend will omit it when setting up known facts. 

## Checklist

*Reviewee: David Thornton* (Replace with your name)
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date