### PR TITLE
DL-5265 fix backlink where error validation message displayed

### DIFF
--- a/app/controllers/SubscriptionController.scala
+++ b/app/controllers/SubscriptionController.scala
@@ -74,7 +74,8 @@ class SubscriptionController @Inject()(mcc: MessagesControllerComponents,
   def register: Action[AnyContent] = Action.async { implicit req =>
     clientAction { implicit user =>
       appointAgentForm.bindFromRequest.fold(
-        formWithErrors => Future.successful(BadRequest(templateAppointAgent(formWithErrors))),
+        formWithErrors => Future.successful(BadRequest(templateAppointAgent(formWithErrors,
+          Some(controllers.routes.SubscriptionController.subscribe().url)))),
         _ => redirectToSubscription("microservice.services.business-customer.serviceRedirectUrl")
       )
     }

--- a/test/controllers/SubscriptionControllerSpec.scala
+++ b/test/controllers/SubscriptionControllerSpec.scala
@@ -232,6 +232,8 @@ class SubscriptionControllerSpec extends PlaySpec with GuiceOneServerPerSuite wi
           registerWithAuthorisedUser(inputForm) { result =>
             val document = Jsoup.parse(contentAsString(result))
             document.getElementById("appointAgent-true-error").text() must be("There is a problem with the appoint an agent question")
+            document.getElementById("backLinkHref").text() must be("Back")
+            document.getElementById("backLinkHref").attr("href") must be("/ated-subscription/start-subscription")
             status(result) must be(BAD_REQUEST)
           }
         }


### PR DESCRIPTION
DL-5265

Fix issue where backlink on /ated-subscription/appoint-agent view. Back link to /;start-subscription was disappearing from view when the error validation message was being displayed when user had not selected an answer and clicked Register

Issue seems to be linked to formWithErrors which was not being passed the backlink (optional)
Added unit tests to check for presence when error validation is displayed

Run ATs for ATED Subscription (unaffected by this change)

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date