### PR TITLE
DL-5514 ATED Accessibility: Labels or instructions - investigation

### DIFF
--- a/app/forms/AtedForms.scala
+++ b/app/forms/AtedForms.scala
@@ -33,7 +33,7 @@ object AtedForms {
   """^(?!\.)("([^"\r\\]|\\["\r\\])*"|([-a-zA-Z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)@[a-zA-Z0-9][\w\.-]*[a-zA-Z0-9]\.[a-zA-Z][a-zA-Z\.]*[a-zA-Z]$""".r
   val addressLineLength = 35
   val PostcodeLength = 10
-  val PostCodeRegex = "^[A-Z]{1,2}[0-9][0-9A-Z]?\\s?[0-9][A-Z]{2}|BFPO\\s?[0-9]{1,10}$"
+  val PostCodeRegex = "^[a-zA-Z]{1,2}[0-9][0-9a-zA-Z]?\\s?[0-9][a-zA-Z]{2}|BFPO\\s?[0-9]{1,10}$"
   val countryLength = 2
   val emailLength = 241
   val lengthZero = 0


### PR DESCRIPTION
DL-5514 ATED Accessibility: Labels or instructions - investigation

Force postcode input to use uppercase to prevent validation failures when lowercase fails in the backend

Simple class with CSS `text-transform: uppercase;` prevents lowercase entry into field. The field should now only fail if the postcode is actually invalid and not when it's been entered in lowercase.