### PR TITLE
DL-6759: Remove BOM from country-codes.properties

### DIFF
--- a/conf/country-code.properties
+++ b/conf/country-code.properties
@@ -1,4 +1,4 @@
-﻿AD=Andorra
+AD=Andorra
 AE=United Arab Emirates
 AF=Afghanistan
 AG=Antigua and Barbuda


### PR DESCRIPTION
Sanitised properties file that was prepending hidden character to start of file.