### PR TITLE
DL-13126 Back link bug

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -16,6 +16,8 @@
 
 package config
 
+import play.api.routing.sird.?
+
 import javax.inject.Inject
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import utils.AtedSubscriptionUtils
@@ -82,6 +84,9 @@ class ApplicationConfig @Inject()(val servicesConfig: ServicesConfig,
 
   lazy val backToBusinessCustomerUrl: String = servicesConfig.getConfString("business-customer.backLinkUrl",
     "/business-customer/back-link/ATED")
+
+  lazy val backToSearchPreviousNrlUrl: String = servicesConfig.getConfString("agent-client-mandate-frontend.searchPreviousNrlUrl",
+    "/mandate/agent/search-previous/nrl")
 
   lazy val toBusinessAccountUrl: String = servicesConfig.getConfString("business-tax-account.serviceRedirectUrl", "/business-account")
 

--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 package config
-
-import play.api.routing.sird.?
 
 import javax.inject.Inject
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig

--- a/app/controllers/RegisteredBusinessController.scala
+++ b/app/controllers/RegisteredBusinessController.scala
@@ -68,10 +68,18 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
                                  (implicit hc: HeaderCarrier, ec: ExecutionContext,
                                   auth: AtedSubscriptionAuthData,
                                   req: Request[AnyContent], messages: Messages): Future[Result] = {
-    val standardView =
+    val backLinkUrlFromAcm: Option[String] = req.queryString.get("backLinkUrl").map(s => s.headOption.getOrElse(""))
+    val standardView = {
+      if (backLinkUrlFromAcm.getOrElse("") contains "/mandate/agent/search-previous/nrl") {
       Future.successful(Ok(template(businessAddressForm.fill(
         businessReg.getOrElse(BusinessAddress())), address, Some(appConfig.backToSearchPreviousNrlUrl))
       ))
+    }
+      else {
+        Future.successful(Ok(template(businessAddressForm.fill(
+          businessReg.getOrElse(BusinessAddress())), address, Some(appConfig.backToBusinessCustomerUrl))
+        ))
+      }}
 
     atedUsers match {
       case Some(users) =>
@@ -103,7 +111,7 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
         businessAddressForm.bindFromRequest().fold(
           formWithErrors => {
             registeredBusinessService.getDefaultCorrespondenceAddress().map { address =>
-              BadRequest(template(formWithErrors, address, Some(appConfig.backToSearchPreviousNrlUrl)))
+              BadRequest(template(formWithErrors, address, Some(appConfig.backToBusinessCustomerUrl)))
             }
           }
           ,

--- a/app/controllers/RegisteredBusinessController.scala
+++ b/app/controllers/RegisteredBusinessController.scala
@@ -113,8 +113,7 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
             registeredBusinessService.getDefaultCorrespondenceAddress().map { address =>
               BadRequest(template(formWithErrors, address, Some(appConfig.backToBusinessCustomerUrl)))
             }
-          }
-          ,
+          },
           businessAddressData => {
             dataCacheConnector.saveRegisteredBusinessDetails(businessAddressData)
             val isCorrespondenceAddress = businessAddressData.isCorrespondenceAddress.getOrElse(false)

--- a/app/controllers/RegisteredBusinessController.scala
+++ b/app/controllers/RegisteredBusinessController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,13 +70,8 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
                                   req: Request[AnyContent], messages: Messages): Future[Result] = {
     val standardView =
       Future.successful(Ok(template(businessAddressForm.fill(
-        //businessReg.getOrElse(BusinessAddress())), address, Some(appConfig.serviceRedirectUrl("agent-client-mandate-frontend.searchPreviousNrlUrl")))
         businessReg.getOrElse(BusinessAddress())), address, Some(appConfig.backToSearchPreviousNrlUrl))
-        //businessReg.getOrElse(BusinessAddress())), address, Some(controllers.routes.RegisteredBusinessController.continue.url))
       ))
-
-//    def test (redirectName: String): Future[Result] = {
-//      Future.successful(Redirect(appConfig.serviceRedirectUrl(redirectName)))
 
     atedUsers match {
       case Some(users) =>
@@ -108,11 +103,9 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
         businessAddressForm.bindFromRequest().fold(
           formWithErrors => {
             registeredBusinessService.getDefaultCorrespondenceAddress().map { address =>
-              //BadRequest(template(formWithErrors, address, Some(appConfig.serviceRedirectUrl("agent-client-mandate-frontend.searchPreviousNrlUrl"))))
               BadRequest(template(formWithErrors, address, Some(appConfig.backToSearchPreviousNrlUrl)))
-              //BadRequest(template(formWithErrors, address, Some(controllers.routes.RegisteredBusinessController.continue.url)))
             }
-          }// _ => test("agent-client-mandate-frontend.searchPreviousNrlUrl")
+          }
           ,
           businessAddressData => {
             dataCacheConnector.saveRegisteredBusinessDetails(businessAddressData)

--- a/app/controllers/RegisteredBusinessController.scala
+++ b/app/controllers/RegisteredBusinessController.scala
@@ -70,8 +70,13 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
                                   req: Request[AnyContent], messages: Messages): Future[Result] = {
     val standardView =
       Future.successful(Ok(template(businessAddressForm.fill(
-        businessReg.getOrElse(BusinessAddress())), address, Some(appConfig.backToBusinessCustomerUrl))
+        //businessReg.getOrElse(BusinessAddress())), address, Some(appConfig.serviceRedirectUrl("agent-client-mandate-frontend.searchPreviousNrlUrl")))
+        businessReg.getOrElse(BusinessAddress())), address, Some(appConfig.backToSearchPreviousNrlUrl))
+        //businessReg.getOrElse(BusinessAddress())), address, Some(controllers.routes.RegisteredBusinessController.continue.url))
       ))
+
+//    def test (redirectName: String): Future[Result] = {
+//      Future.successful(Redirect(appConfig.serviceRedirectUrl(redirectName)))
 
     atedUsers match {
       case Some(users) =>
@@ -103,9 +108,12 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
         businessAddressForm.bindFromRequest().fold(
           formWithErrors => {
             registeredBusinessService.getDefaultCorrespondenceAddress().map { address =>
-              BadRequest(template(formWithErrors, address, Some(appConfig.backToBusinessCustomerUrl)))
+              //BadRequest(template(formWithErrors, address, Some(appConfig.serviceRedirectUrl("agent-client-mandate-frontend.searchPreviousNrlUrl"))))
+              BadRequest(template(formWithErrors, address, Some(appConfig.backToSearchPreviousNrlUrl)))
+              //BadRequest(template(formWithErrors, address, Some(controllers.routes.RegisteredBusinessController.continue.url)))
             }
-          },
+          }// _ => test("agent-client-mandate-frontend.searchPreviousNrlUrl")
+          ,
           businessAddressData => {
             dataCacheConnector.saveRegisteredBusinessDetails(businessAddressData)
             val isCorrespondenceAddress = businessAddressData.isCorrespondenceAddress.getOrElse(false)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -103,6 +103,7 @@ microservice {
       agentAtedSummaryUrl: "http://localhost:9959/mandate/agent/summary"
       clientDisplayNameEditUrl: "http://localhost:9959/mandate/agent/client-display-name?redirectUrl=http://localhost:9933/ated-subscription/review-business-details"
       agentEmailEditUrl: "http://localhost:9959/mandate/agent/email?redirectUrl=http://localhost:9933/ated-subscription/review-business-details"
+      searchPreviousNrlUrl: "http://localhost:9959/mandate/agent/search-previous/nrl"
     }
     government-gateway {
       host = localhost


### PR DESCRIPTION
# DL-13126 Fixed back link bug in registered business controller

**Bug fix**

Fixed the back link bug in the registered business controller so it takes the user back to the correct page in all journeys covered in the ATs. Additionally the AT covering the problem page has been removed as requested - see https://github.com/hmrc/agent-client-mandate-acceptance-tests/pull/84.

## Checklist

*Stuart*
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date