### PR TITLE
DL 12743 - Allowing users to reclaim enrolment despite delegated enrolment existing

### DIFF
--- a/app/controllers/RegisteredBusinessController.scala
+++ b/app/controllers/RegisteredBusinessController.scala
@@ -83,7 +83,7 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
 
     atedUsers match {
       case Some(users) =>
-        if(users.principalUserIds == Nil) {
+        if(users.principalGroupIds == Nil) {
           etmpCheckService.validateBusinessDetails(bcDetails) flatMap { etmpRegistered =>
             if (etmpRegistered) {
               authoriseFor { newAuthDetails =>

--- a/app/controllers/RegisteredBusinessController.scala
+++ b/app/controllers/RegisteredBusinessController.scala
@@ -83,7 +83,7 @@ class RegisteredBusinessController @Inject()(mcc: MessagesControllerComponents,
 
     atedUsers match {
       case Some(users) =>
-        if(users.principalUserIds == Nil && users.delegatedUserIds == Nil) {
+        if(users.principalUserIds == Nil) {
           etmpCheckService.validateBusinessDetails(bcDetails) flatMap { etmpRegistered =>
             if (etmpRegistered) {
               authoriseFor { newAuthDetails =>

--- a/app/models/AtedUsers.scala
+++ b/app/models/AtedUsers.scala
@@ -18,7 +18,7 @@ package models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class AtedUsers(principalUserIds: List[String], delegatedUserIds: List[String])
+case class AtedUsers(principalGroupIds: List[String], delegatedGroupIds: List[String])
 
 
 object AtedUsers {

--- a/test/connectors/AtedConnectorSpec.scala
+++ b/test/connectors/AtedConnectorSpec.scala
@@ -74,7 +74,7 @@ class AtedConnectorSpec extends PlaySpec with GuiceOneServerPerSuite with Mockit
         verify(mockWSHttp, times(1)).GET[HttpResponse](any(), any(), any())(any(), any(), any())
       }
 
-      "GET user enrolments for a given safeID should return the list of enrolments" in {
+      "GET user enrolments for a given safeID should return the list of group IDs" in {
         val atedUsersList = AtedUsers(List("principalUserId1"), List("delegatedId1"))
         implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
         val jsOnData = Json.toJson(atedUsersList)


### PR DESCRIPTION
# DL 12743 - Allowing users to reclaim enrolment despite delegated enrolment existing

**Bug fix**

Removing the check for delegated enrolments including switching to use the ES1 call rather than ES0 call, to check for groups rather than users. This will enable users to reclaim their ATED enrolment when their creds have been deleted even if a delegated enrolment exists. Please see also PRs for the backend (https://github.com/hmrc/ated-subscription/pull/60) and acceptance tests (https://github.com/hmrc/ated-acceptance-tests/pull/155)

## Checklist

*Stuart*
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date